### PR TITLE
Install node_exporter inside Docker image

### DIFF
--- a/CocovoitAPI/CocovoitAPI/Dockerfile
+++ b/CocovoitAPI/CocovoitAPI/Dockerfile
@@ -15,8 +15,19 @@ RUN dotnet publish -c Release -o out
 # On crée l'image de l'application
 FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS runtime
 WORKDIR /app
-COPY --from=build /app/out ./
-EXPOSE 80
 
-# On configure le point d'entrée pour démarrer l'application
-ENTRYPOINT ["dotnet", "CocovoitAPI.dll"]
+# Installation de node_exporter pour exposer les métriques Prometheus
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends wget ca-certificates \
+    && wget -q https://github.com/prometheus/node_exporter/releases/download/v1.8.1/node_exporter-1.8.1.linux-amd64.tar.gz \
+    && tar -xzf node_exporter-1.8.1.linux-amd64.tar.gz \
+    && mv node_exporter-1.8.1.linux-amd64/node_exporter /usr/local/bin/ \
+    && rm -rf node_exporter-1.8.1.linux-amd64* \
+    && apt-get purge -y --auto-remove wget \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /app/out ./
+EXPOSE 80 9100
+
+# Démarrage de l'API et de node_exporter
+ENTRYPOINT ["sh", "-c", "node_exporter & exec dotnet CocovoitAPI.dll"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # Back
+
+Cette image Docker contient l'API .NET et expose également les métriques Prometheus via **node_exporter**.
+
+Le serveur d'API écoute sur le port `80` et les métriques sont disponibles sur le port `9100`.
+
+Dans `docker-compose.yml`, ces ports sont mappés respectivement sur `44318` et `9100`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
     container_name: cocovoit_restapi
     ports:
       - "44318:80"
+      - "9100:9100"
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
     depends_on:


### PR DESCRIPTION
## Summary
- add node_exporter setup in Dockerfile
- expose metrics port in docker-compose
- document exposed ports

## Testing
- `dotnet test ./CocovoitAPI --no-build --verbosity normal` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6866c20fe698832b91b90bb8cfc24a05