### PR TITLE
Add OS log export to Alloy

### DIFF
--- a/CocovoitAPI/CocovoitAPI/Dockerfile
+++ b/CocovoitAPI/CocovoitAPI/Dockerfile
@@ -26,8 +26,19 @@ RUN apt-get update \
     && apt-get purge -y --auto-remove wget \
     && rm -rf /var/lib/apt/lists/*
 
+# Installation de Grafana Alloy pour l'envoi des logs vers Loki
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates \
+    && curl -fsSL -o /usr/local/bin/alloy \
+        https://github.com/grafana/alloy/releases/latest/download/alloy-linux-amd64 \
+    && chmod +x /usr/local/bin/alloy \
+    && apt-get purge -y --auto-remove curl \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY --from=build /app/out ./
+COPY alloy.yml /etc/alloy/alloy.yml
+RUN mkdir -p /var/log/cocovoit
 EXPOSE 80 9100
 
-# Démarrage de l'API et de node_exporter
-ENTRYPOINT ["sh", "-c", "node_exporter & exec dotnet CocovoitAPI.dll"]
+# Démarrage de l'API, de node_exporter et d'Alloy avec log vers /var/log/cocovoit
+ENTRYPOINT ["sh", "-c", "node_exporter & alloy run /etc/alloy/alloy.yml & dotnet CocovoitAPI.dll 2>&1 | tee -a /var/log/cocovoit/api.log"]

--- a/CocovoitAPI/CocovoitAPI/alloy.yml
+++ b/CocovoitAPI/CocovoitAPI/alloy.yml
@@ -1,0 +1,22 @@
+logging {
+  level = "info"
+}
+
+loki.source.file "api_logs" {
+  targets    = ["/var/log/cocovoit/*.log"]
+  labels     = { job = "cocovoit" }
+  forward_to = [loki.write.loki.receiver]
+}
+
+# Export des logs du système présents dans /var/log
+loki.source.file "system_logs" {
+  targets    = ["/var/log/syslog", "/var/log/*.log"]
+  labels     = { job = "system" }
+  forward_to = [loki.write.loki.receiver]
+}
+
+loki.write "loki" {
+  endpoint {
+    url = env("LOKI_URL")
+  }
+}

--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@ Cette image Docker contient l'API .NET et expose également les métriques Prome
 Le serveur d'API écoute sur le port `80` et les métriques sont disponibles sur le port `9100`.
 
 Dans `docker-compose.yml`, ces ports sont mappés respectivement sur `44318` et `9100`.
+
+L'image intègre également **Grafana Alloy** afin d'envoyer les logs de l'application vers une instance Loki. L'URL de Loki doit être fournie via la variable d'environnement `LOKI_URL`.
+Les logs de l'API sont écrits dans `/var/log/cocovoit/api.log` et sont exportés via Alloy.
+Alloy collecte aussi les journaux système présents dans `/var/log` pour les transmettre à Loki.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,8 +34,12 @@ services:
       - "9100:9100"
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
+      - LOKI_URL=http://loki:3100
     depends_on:
       - mysql
+    volumes:
+      - logs:/var/log/cocovoit
 
 volumes:
   mysql_data:
+  logs:


### PR DESCRIPTION
## Summary
- update Alloy config to read OS log files from `/var/log`
- document that Alloy forwards system logs to Loki

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6866f82fcfd0832ba05b7d81fd5f4707